### PR TITLE
Added highlighting for hashtags, mentions, URLs in Tweets.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2296,6 +2296,15 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/dompurify": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-2.3.2.tgz",
+      "integrity": "sha512-iht/O0jie/hDur39Z1NzjfOT/O9Kn2aWY99aqOn7lwsjSttEoMyGWvZIuAzZy0cNvAZdjmqySp7Z4d3GfBEGQw==",
+      "dev": true,
+      "requires": {
+        "@types/trusted-types": "*"
+      }
+    },
     "@types/eslint": {
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.29.0.tgz",
@@ -2569,6 +2578,12 @@
       "requires": {
         "@types/jest": "*"
       }
+    },
+    "@types/trusted-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.2.tgz",
+      "integrity": "sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg==",
+      "dev": true
     },
     "@types/uglify-js": {
       "version": "3.13.1",
@@ -5345,6 +5360,11 @@
           "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A=="
         }
       }
+    },
+    "dompurify": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.3.4.tgz",
+      "integrity": "sha512-6BVcgOAVFXjI0JTjEvZy901Rghm+7fDQOrNIcxB4+gdhj6Kwp6T9VBhBY/AbagKHJocRkDYGd6wvI+p4/10xtQ=="
     },
     "domutils": {
       "version": "1.7.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@types/react": "^17.0.38",
     "@types/react-dom": "^17.0.11",
     "dateformat": "^5.0.2",
+    "dompurify": "^2.3.4",
     "prop-types": "^15.7.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
@@ -45,5 +46,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "@types/dompurify": "^2.3.2"
   }
 }

--- a/src/App.js
+++ b/src/App.js
@@ -9,6 +9,9 @@ function App() {
     verified: false,
     pfp_link: null,
     tweet_body: null,
+    tweet_urls: [],
+    tweet_hashtags: [],
+    tweet_mentions: [],
     timestamp: null,
     replies: null,
     retweets: null,
@@ -29,6 +32,9 @@ function App() {
           verified={snippet.verified}
           pfp_link={snippet.pfp_link}
           tweet_body={snippet.tweet_body}
+          tweet_urls={snippet.tweet_urls}
+          tweet_hashtags={snippet.tweet_hashtags}
+          tweet_mentions={snippet.tweet_mentions}
           timestamp={snippet.timestamp}
           replies={snippet.replies}
           retweets={snippet.retweets}

--- a/src/components/SnipLinkBox.js
+++ b/src/components/SnipLinkBox.js
@@ -57,6 +57,9 @@ function SnipLinkBox({ setTweetComponentProps }) {
                   includedUserData.profile_image_url
                 ),
                 tweet_body: tweetData.text,
+                tweet_urls: tweetData.entities.urls,
+                tweet_hashtags: tweetData.entities.hashtags,
+                tweet_mentions: tweetData.entities.mentions,
                 timestamp: new Date(tweetData.created_at),
                 replies: prettifyTweetMetric(
                   tweetData.public_metrics.reply_count

--- a/src/components/Tweet.css
+++ b/src/components/Tweet.css
@@ -13,6 +13,10 @@
   margin-left: auto;
 }
 
+.tweet-tag {
+  color: #1da1f2;
+}
+
 #verify-badge {
   margin-left: 5px;
   width: 25px;
@@ -65,4 +69,8 @@
 .timestamp {
   color: #777674;
   font-size: x-large;
+}
+
+#tweet-body-text {
+  margin-bottom: 0;
 }

--- a/src/components/Tweet.js
+++ b/src/components/Tweet.js
@@ -3,13 +3,18 @@ import "./Tweet.css";
 import { faTwitter } from "@fortawesome/free-brands-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import dateFormat from "dateformat";
+import { highlightTweetTags } from "../utils/tweet_utils";
 import PropTypes from "prop-types";
+import DOMPurify from "dompurify";
 function Tweet(props) {
   const {
     name,
     handle,
     verified,
     pfp_link,
+    tweet_urls,
+    tweet_hashtags,
+    tweet_mentions,
     tweet_body,
     timestamp,
     replies,
@@ -41,7 +46,19 @@ function Tweet(props) {
           <FontAwesomeIcon id="twitter-logo" icon={faTwitter} size="3x" />
         </div>
         <div className="tweet-body">
-          <p style={{ marginBottom: 0 }}>{tweet_body}</p>
+          <div
+            style={{ marginBottom: 0 }}
+            dangerouslySetInnerHTML={{
+              __html: DOMPurify.sanitize(
+                highlightTweetTags(
+                  tweet_body,
+                  tweet_urls,
+                  tweet_hashtags,
+                  tweet_mentions
+                )
+              ),
+            }}
+          ></div>
         </div>
         <div className="timestamp">
           <p>{dateFormat(timestamp, "h:MM TT • d mmm, yyyy")}</p>
@@ -75,6 +92,9 @@ Tweet.propTypes = {
   name: PropTypes.string.isRequired,
   handle: PropTypes.string.isRequired,
   verified: PropTypes.bool,
+  tweet_urls: PropTypes.array.isRequired,
+  tweet_hashtags: PropTypes.array.isRequired,
+  tweet_mentions: PropTypes.array.isRequired,
   tweet_body: PropTypes.string.isRequired,
   replies: PropTypes.string.isRequired,
   retweets: PropTypes.string.isRequired,

--- a/src/utils/tweet_utils.ts
+++ b/src/utils/tweet_utils.ts
@@ -1,3 +1,5 @@
+import { TweetURL, TweetHashtag, TweetMention } from "./types/types";
+
 /**
  * Retrieves the full-size profile picture link corresponding to the Tweet poster.
  * @param {string} small_icon_url The 48x48 pixel profile picture link returned by the twitter API
@@ -11,6 +13,32 @@ export const getFullSizePfpLink = (small_icon_url: string): string => {
     throw Error("Provided URL did not contain _normal.jpg image suffix.");
   }
 };
+
+
+export const highlightTweetTags = (tweet_body: string, urls?: Array<TweetURL>, hashtags?: Array<TweetHashtag>, mentions?: Array<TweetMention>): string => {
+  tweet_body = `<p id="tweet-body-text">${tweet_body}</p>`
+  console.log(urls)
+  if(urls) {
+    urls.forEach(url => {
+      tweet_body = tweet_body.replace(`${url.url}`, `<span class="tweet-tag">${url.url}</span>`)
+    })
+  }
+
+  if(hashtags){
+    hashtags.forEach(hashtag => {
+      tweet_body = tweet_body.replace(`#${hashtag.tag}`, `<span class="tweet-tag">#${hashtag.tag}</span>`)
+    });
+  }
+
+  if(mentions) {
+    mentions.forEach(mention => {
+      tweet_body = tweet_body.replace(`@${mention.username}`, `<span class="tweet-tag">@${mention.username}</span>`)
+    });
+  }
+
+
+  return tweet_body
+}
 
 /**
  * "Prettifies" a number to make it follow Twitter's standard.

--- a/src/utils/types/types.ts
+++ b/src/utils/types/types.ts
@@ -1,0 +1,20 @@
+export interface TweetURL{
+    start: number,
+    end: number,
+    url: string,
+    expanded_url: string,
+    display_url: string,
+};
+  
+export interface TweetHashtag {
+    start: number,
+    end: number,
+    tag: string,
+};
+  
+export interface TweetMention {
+    start: number,
+    end: number;
+    username: string,
+    id: string,
+};


### PR DESCRIPTION
* Add DOMPurify dependency because the only logical way to do this highlighting was calling `dangerouslySetInnerHTML` on a div and set it accordingly. Sanitizing the compiled HTML string helps to prevent XSS. 
* Hashtags, mentions, and URLs are now all highlighted in Tweets.