### PR TITLE
Documented highlightTweetTags function

### DIFF
--- a/src/components/Tweet.js
+++ b/src/components/Tweet.js
@@ -5,7 +5,6 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import dateFormat from "dateformat";
 import { highlightTweetTags } from "../utils/tweet_utils";
 import PropTypes from "prop-types";
-import DOMPurify from "dompurify";
 function Tweet(props) {
   const {
     name,
@@ -49,13 +48,11 @@ function Tweet(props) {
           <div
             style={{ marginBottom: 0 }}
             dangerouslySetInnerHTML={{
-              __html: DOMPurify.sanitize(
-                highlightTweetTags(
-                  tweet_body,
-                  tweet_urls,
-                  tweet_hashtags,
-                  tweet_mentions
-                )
+              __html: highlightTweetTags(
+                tweet_body,
+                tweet_urls,
+                tweet_hashtags,
+                tweet_mentions
               ),
             }}
           ></div>

--- a/src/utils/tweet_utils.ts
+++ b/src/utils/tweet_utils.ts
@@ -1,5 +1,5 @@
 import { TweetURL, TweetHashtag, TweetMention } from "./types/types";
-
+import DOMPurify from "dompurify";
 /**
  * Retrieves the full-size profile picture link corresponding to the Tweet poster.
  * @param {string} small_icon_url The 48x48 pixel profile picture link returned by the twitter API
@@ -14,7 +14,18 @@ export const getFullSizePfpLink = (small_icon_url: string): string => {
   }
 };
 
-
+/**
+ * Generates HTML used to populate the Tweet component's body. With real Tweets,
+ * @ (mentions), # (hashtags), and URLs are highlighted. This function does the same
+ * generating an HTML string. The HTML string is sanitized using DOMPurify before
+ * being returned.
+ * 
+ * @param tweet_body The plaintext of the tweet, without any highlighting 
+ * @param urls  An array of URLs contained within the tweet, returned by the Twitter API
+ * @param hashtags An array of hashtags contained within the tweet, returned by the Twitter API
+ * @param mentions An array of mentions contained within the tweet, returned by the Twitter API
+ * @returns A sanitized HTML string, with correct styling applied for mentions, URLs, and hashtags
+ */
 export const highlightTweetTags = (tweet_body: string, urls?: Array<TweetURL>, hashtags?: Array<TweetHashtag>, mentions?: Array<TweetMention>): string => {
   tweet_body = `<p id="tweet-body-text">${tweet_body}</p>`
   console.log(urls)
@@ -37,7 +48,7 @@ export const highlightTweetTags = (tweet_body: string, urls?: Array<TweetURL>, h
   }
 
 
-  return tweet_body
+  return DOMPurify.sanitize(tweet_body)
 }
 
 /**


### PR DESCRIPTION
* Added JSDoc comment to `highlightTweetTags` utility function. 
* Moved `DOMPurify.sanitize` function call to inside `highlightTweetTags` function in case it gets reused somewhere else, that way we don't have to worry about calling `DOMPurify.sanitize` elsewhere, we can then always guarantee the  HTML string returned by `highlightTweetTags` will be clean. 